### PR TITLE
feat(Wrappers): Implement Reverse

### DIFF
--- a/src/utilities.js
+++ b/src/utilities.js
@@ -28,3 +28,15 @@ export const createCommonKnobs = knobs => {
         timingFn: knobs.text('timingFn', defaultAnimationProps.timingFn),
     };
 };
+
+export const onceEvery = function(times, func) {
+    const orig = times;
+    return function() {
+        if (--times < 1) {
+            times = orig;
+            return func.apply(this, arguments);
+        }
+
+        return null;
+    };
+};

--- a/src/wrappers/Random/index.jsx
+++ b/src/wrappers/Random/index.jsx
@@ -1,10 +1,10 @@
 import React, { Component } from 'react';
 import { bool, func, node, number } from 'prop-types';
 import TransitionGroup from 'react-transition-group/TransitionGroup';
-import _after from 'lodash/after';
 import _omit from 'lodash/omit';
+import _reverse from 'lodash/reverse';
 
-import { defaultAnimationProps } from 'utilities';
+import { defaultAnimationProps, onceEvery } from 'utilities';
 
 export const getRandomDelay = (minDelay, maxDelay) => {
     const delay = Math.round(Math.random() * maxDelay);
@@ -20,10 +20,12 @@ class Random extends Component {
         getRandomDelay(this.props.minDelay, this.props.maxDelay)
     );
 
+    reversedDelays = _reverse([...this.delays]);
+
     onCompleteTimeout = null;
     totalChildren = React.Children.count(this.props.children);
 
-    onComplete = _after(this.totalChildren, () => {
+    onComplete = onceEvery(this.totalChildren, () => {
         const maxDelay = Math.max(...this.delays);
 
         this.onCompleteTimeout = setTimeout(
@@ -40,20 +42,24 @@ class Random extends Component {
             'maxDelay',
             'minDelay',
             'onComplete',
+            'reverse',
         ]);
     }
 
     render() {
-        const { children, duration, in: inProp } = this.props;
+        const { children, duration, in: inProp, reverse } = this.props;
+
+        const delays = reverse ? this.reversedDelays : this.delays;
 
         return (
             <TransitionGroup {...this.getTransitionProps()}>
                 {inProp &&
                     React.Children.map(children, (child, i) =>
                         React.cloneElement(child, {
-                            delay: this.delays[i],
+                            delay: delays[i],
                             duration,
                             onEntered: this.onComplete,
+                            onExited: this.onComplete,
                         })
                     )}
             </TransitionGroup>
@@ -67,6 +73,7 @@ Random.propTypes = {
     maxDelay: number,
     minDelay: number,
     onComplete: func,
+    reverse: bool,
 };
 
 Random.defaultProps = {
@@ -75,6 +82,7 @@ Random.defaultProps = {
     maxDelay: 1500,
     minDelay: 0,
     onComplete: Function.prototype,
+    reverse: false,
 };
 
 export default Random;

--- a/stories/Random.js
+++ b/stories/Random.js
@@ -12,6 +12,7 @@ storiesOf('Wrappers/Random', module)
     .add('default', () => (
         <Random
             in={boolean('in', true)}
+            reverse={boolean('reverse', false)}
             minDelay={number('minDelay', 0)}
             maxDelay={number('maxDelay', 1500)}
         >

--- a/stories/Stagger.js
+++ b/stories/Stagger.js
@@ -10,7 +10,11 @@ const exampleArray = ['Example', 'Example', 'Example', 'Example', 'Example'];
 storiesOf('Wrappers/Stagger', module)
     .addDecorator(withKnobs)
     .add('default', () => (
-        <Stagger in={boolean('in', true)} chunk={number('chunk', 0)}>
+        <Stagger
+            in={boolean('in', true)}
+            reverse={boolean('reverse', false)}
+            chunk={number('chunk', 0)}
+        >
             {exampleArray.map((example, i) => (
                 <Fade key={`${i}-example`}>
                     <h1>{example}</h1>


### PR DESCRIPTION
Allow users to pass `reverse` to reverse the way the delays are applied in `Stagger` and `Random`.
Also includes a bug fix where `onComplete` was not called `onExited` and was being called multiple
times